### PR TITLE
Dynamic globals

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -15,6 +15,8 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('browserify', 'Grunt task for browserify.', function () {
     var done = this.async();
 
+    var opts = grunt.util._.extend(this.data.options, {}) || {};
+    
     var files = this.filesSrc.map(function (file) {
       return path.resolve(file);
     });
@@ -23,6 +25,11 @@ module.exports = function (grunt) {
     b.on('error', function (err) {
       grunt.fail.warn(err);
     });
+
+    var globals = opts.globals || {};
+    for(var key in globals) {
+      b.require(globals[key], { expose: key, entry: true });
+    }
 
     if (this.data.ignore) {
       grunt.file.expand({filter: 'isFile'}, this.data.ignore)
@@ -60,7 +67,6 @@ module.exports = function (grunt) {
       });
     }
 
-    var opts = grunt.util._.extend(this.data.options, {});
     var bundle = b.bundle(opts);
     bundle.on('error', function (err) {
       grunt.fail.warn(err);


### PR DESCRIPTION
Option to add provide custom global `process` and `Buffer` implementations, currently only via `grunt-browserify`:

``` javascript
browserify: {
  bundle: {
    src: [],
    require: ['mongodb', 'tcp_wrap-chromeify'],
    dest: 'app/scripts/vendor/bundle.js',
    ignore: 'node_modules/browser-resolve/node_modules/buffer-browserify/index.js',
    options: {
      globals: {
        process: 'browser-resolve/builtin/process',
        Buffer: 'buffer-browserify'
      }
    }
  }
}
```

Needs substack/node-browserify#386 and substack/insert-module-globals#5 to work.

Working implementation here:
https://github.com/amiuhle/chrome-mongo-admin
