### PR TITLE
require array, corresponding to browserify -r option

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -24,6 +24,12 @@ module.exports = function (grunt) {
       grunt.fail.warn(err);
     });
 
+    if(this.data.require) {
+      this.data.require.forEach(function (require) {
+        b.require(require, { expose: require });
+      });
+    }
+
     if (this.data.ignore) {
       grunt.file.expand({filter: 'isFile'}, this.data.ignore)
         .forEach(function (file) {


### PR DESCRIPTION
Example:

``` javascript
browserify: {
  bundle: {
    src: [],
    require: ['mongodb', 'tcp_wrap-chromeify'],
    dest: 'app/scripts/vendor/bundle.js',
    ignore: 'node_modules/browser-resolve/node_modules/buffer-browserify/index.js',
    options: {
      globals: {
        process: 'browser-resolve/builtin/process',
        Buffer: 'buffer-browserify'
      }
    }
  }
}
```
