### PR TITLE
Added functionality for b.require(<file>)

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -64,6 +64,18 @@ module.exports = function (grunt) {
         });
       }
 
+      if (opts.require) {
+        opts.require.forEach(function(lib) {
+          var files = ~lib.indexOf('*')
+            ? (grunt.file.expand(lib))
+            : [lib];
+
+          files.forEach(function (file) {
+            b.require(file);
+          });
+        });
+      }
+
       var bundle = b.bundle(opts);
       bundle.on('error', function (err) {
         grunt.fail.warn(err);


### PR DESCRIPTION
[b.require()](https://github.com/substack/node-browserify#brequirefile-opts) exposes a package so that it can be required outside of the bundle. This is useful when you need to stub/mock dependencies during testing.

I have built this into `grunt-browserify` so that it can be used like so:

``` js
browserify: {
  testable: {
    src: ['lib/index.js'],
    dest: 'build/build-test.js',
    options: {
      require: [
        'event',
        './lib/*/*.js'
      ]
    }
  }
}
```

Enabling:

``` js
window.require('event');
window.require('./lib/dir/file1.js');
window.require('./lib/dir/file2.js');
```
