### PR TITLE
Adding externalize module support.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
 
       alias: {
         src: ['test/fixtures/alias/*.js'],
-        dest: 'tmp/alias.js', 
+        dest: 'tmp/alias.js',
         options: {
           alias: ['test/fixtures/alias/toBeAliased.js:alias']
         }
@@ -67,7 +67,7 @@ module.exports = function (grunt) {
         src: ['test/fixtures/externalize/b.js'],
         dest: 'tmp/externalize.js',
         options: {
-          externalize: ['test/fixtures/externalize/a.js']
+          externalize: ['test/fixtures/externalize/a.js', 'events']
         }
       },
 
@@ -76,7 +76,7 @@ module.exports = function (grunt) {
         dest: 'tmp/shim.js',
         options: {
           shim: {
-            jquery: { 
+            jquery: {
               path: 'test/fixtures/shim/jquery.js',
               exports: 'jquery'
             }

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -69,10 +69,16 @@ module.exports = function (grunt) {
       }
 
       if (opts.externalize) {
-        grunt.file.expand({filter: 'isFile'}, opts.externalize)
-          .forEach(function (file) {
-            b.require(path.resolve(file), {expose: true});
-          });
+        opts.externalize.forEach(function (lib) {
+          if (/\//.test(lib)) {
+            grunt.file.expand({filter: 'isFile'}, lib).forEach(function (file) {
+              b.require(path.resolve(file));
+            });
+          }
+          else {
+            b.require(lib);
+          }
+        });
       }
 
       if (opts.transform) {

--- a/test/browserify_test.js
+++ b/test/browserify_test.js
@@ -77,18 +77,17 @@ module.exports = {
   },
 
   externalize: function (test) {
-    test.expect(3);
+    test.expect(4);
 
     var actual = readFile('tmp/externalize.js');
     var c = {};
     vm.runInNewContext(actual, c);
 
-    //require should be exposed
-    test.ok(c.require);
 
     var depen = browserify();
     depen.external(__dirname + '/fixtures/externalize/a.js');
     depen.add(__dirname + '/fixtures/externalize/entry.js');
+
     depen.bundle(function (err, src) {
       c.required = function (exports) {
         c.exports = exports;
@@ -97,6 +96,12 @@ module.exports = {
 
       test.ok(moduleExported(c, './fixtures/externalize/a.js'));
       test.ok(moduleExported(c, './fixtures/externalize/b.js'));
+
+      //require should be exposed
+      test.ok(c.require);
+      
+      //common module required
+      test.ok(c.require('events'));
 
       test.done();
     });
@@ -158,11 +163,11 @@ function getIncludedModules (file, context) {
 }
 
 function domWindow () {
-  var html = 
+  var html =
     '<!DOCTYPE html>' +
     '<html>' +
-      '<head>' + 
-        '<title>Test</title>' + 
+      '<head>' +
+        '<title>Test</title>' +
       '</head>' +
       '<body>' +
       '</body>' +


### PR DESCRIPTION
`b.require` doesn't just work with files it works with modules too.
Now there's support for specifying files OR modules for grunt-browserify.

This branch includes a manual merge of #39, and adds test coverage as well. 
