### PR TITLE
Compatibility fix for older node versions

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -97,12 +97,11 @@ module.exports = function (grunt) {
         grunt.file.mkdir(destPath);
       }
 
-      bundle
-        .pipe(fs.createWriteStream(file.dest))
-        .on('finish', function () {
-          grunt.log.ok('Bundled ' + file.dest);
-          next();
-        });
+      bundle.pipe(fs.createWriteStream(file.dest));
+      bundle.on('end', function () {
+        grunt.log.ok('Bundled ' + file.dest);
+        next();
+      });
 
     }, this.async());
   });


### PR DESCRIPTION
I was having issues running this task on node v0.8.18. I saw that it's only supposed to run on node >=0.10.x, but npm doesn't enforce this unless you set [`engineStrict`](https://npmjs.org/doc/json.html#engineStrict) to true in your package.json.

Anyways, the only issue I saw was the task would only run one target and then stop. I tracked it down to the events when writing each bundle to a file - the `finish` event doesn't fire in v0.8.18 on the write stream. Not sure if this is a change in node, or a bug in browserify, but this commit fixes that by listening for the `end` event on the bundle stream instead.

If you don't want this changed, I'd suggest turning on `engineStrict` instead, because it definitely doesn't work in v0.8.18.
