### PR TITLE
Switch to callback API from stream API

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -91,8 +91,11 @@ module.exports = function (grunt) {
         grunt.file.mkdir(destPath);
       }
 
-      b.bundle(opts, function(err, src) {
-        if (err) grunt.fail.warn(err);
+      b.bundle(opts, function (err, src) {
+        if (err) {
+          grunt.fail.warn(err);
+        }
+
         grunt.file.write(file.dest, src);
         grunt.log.ok('Bundled ' + file.dest);
         next();


### PR DESCRIPTION
I was having strange issues with partially compiled files. It looked like a streaming issue as there were chunks of the bundle not being written. A simple switch to the `b.bundle()` callback API fixed these issues I was having. 

Unfortunately I cannot reliably reproduce this problem, so you'll just have to choose whether or not to take my word for it. I'm going to be running my fork of this project until (if you choose to) this fix is merged.

All tests still passing.
