### PR TITLE
latest browserify: 2.12.x -> 2.18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "browserify": "~2.12.0",
+    "browserify": "~2.18.0",
     "browserify-shim": "~2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
There are a newer version of browserify module available.

In my case, it's needed to browserify my product.

Tests passed. Thank you anyway.
