### PR TITLE
Adding support for noParse option, which must be passed to browserify(),...

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -16,26 +16,30 @@ var shim = require('browserify-shim');
 module.exports = function (grunt) {
   grunt.registerMultiTask('browserify', 'Grunt task for browserify.', function () {
     var opts = this.options();
+    var ctorOpts = {};
 
-    // parse shims now so they can be added to noParse
+    // parse shims now so they can be added to noParse array
+    // files listed in noParse will be skipped by Browserify
+    // greatly speeding up builds that reference large libs like jQuery
     if (opts.shim) {
       var shims = opts.shim;
-      opts.noParse = opts.noParse || [];
+      ctorOpts.noParse = [].concat(opts.noParse);
+      delete opts.noParse;
       Object.keys(shims)
         .forEach(function (alias) {
           shims[alias].path = path.resolve(shims[alias].path);
-          opts.noParse.push(shims[alias].path);
+          ctorOpts.noParse.push(shims[alias].path);
         });
     }
 
     grunt.util.async.forEachSeries(this.files, function (file, next) {
       var aliases;
 
-      opts.files = grunt.file.expand({filter: 'isFile'}, file.src).map(function (f) {
+      ctorOpts.files = grunt.file.expand({filter: 'isFile'}, file.src).map(function (f) {
         return path.resolve(f);
       });
 
-      var b = browserify(opts);
+      var b = browserify(ctorOpts);
       b.on('error', function (err) {
         grunt.fail.warn(err);
       });


### PR DESCRIPTION
... not bundle(). Auto add all shimmed files to noParse since they obviously don't need parsing. Not sure how to go about testing this, but it definitely works because it halved my build time. If you have suggestions on how to test let me know and I will add them.
