### PR TITLE
Allow aliases to items with slashes in them

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -65,13 +65,15 @@ module.exports = function (grunt) {
           alias = alias.split(':');
           var aliasSrc = alias[0];
           var aliasDest = alias[1];
+          var aliasDestResolved;
 
           if (/\//.test(aliasSrc)) {
             aliasSrc = path.resolve(aliasSrc);
           }
-          //if the alias exists and is a filepath, resolve it
+          //if the alias exists and is a filepath, resolve it if it's a valid path
           if (aliasDest && /\//.test(aliasDest)) {
-            aliasDest = path.resolve(aliasDest);
+            aliasDestResolved = path.resolve(aliasDest)
+            aliasDest = grunt.file.exists(aliasDestResolved) && grunt.file.isFile(aliasDestResolved) ? aliasDestResolved : aliasDest;
           }
 
           if (!aliasDest) {


### PR DESCRIPTION
I ran into a problem where I needed to alias a file to a string with a "/" in it. Unfortunately, the current behavior is to assumes that the alias destination should be resolved into a path.

I'm not sure why that behavior is useful, but proceeding on the assumption that it is, this patch checks to see if the expanded path actually exists before aliasing it. If it doesn't exist, it leaves the alias destination as is.
