### PR TITLE
Allow aliasing inner modules (/ in alias src)

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -68,10 +68,14 @@ module.exports = function (grunt) {
           alias = alias.split(':');
           var aliasSrc = alias[0];
           var aliasDest = alias[1];
-          var aliasDestResolved;
+          var aliasDestResolved, aliasSrcResolved;
 
+          // if the source has '/', it might be an inner module; resolve as filepath
+          // only if it's a valid one
           if (/\//.test(aliasSrc)) {
-            aliasSrc = path.resolve(aliasSrc);
+            aliasSrcResolved = path.resolve(aliasSrc);
+            aliasSrc = grunt.file.exists(aliasSrcResolved) && grunt.file.isFile(aliasSrcResolved) ?
+              aliasSrcResolved : aliasSrc;
           }
           //if the alias exists and is a filepath, resolve it if it's a valid path
           if (aliasDest && /\//.test(aliasDest)) {


### PR DESCRIPTION
I've run into a problem when trying to alias an inner module (e.g. jade/runtime). This patch allows alias sources to have '/', and fixes the problem where `grunt-browserify` assumes the source to be a path, because it contains a '/'.
