### PR TITLE
Add option to stand up http server to for browserify bundle

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,15 @@ module.exports = function (grunt) {
         dest: 'tmp/basic.js'
       },
 
+      onTheFlyBundle: {
+        src: ['test/fixtures/basic/*.js'],
+        dest: 'tmp/basic.js',
+        options: {
+          serveBundle: true,
+          port: 8080
+        }
+      },
+
       ignores: {
         src: ['test/fixtures/ignore/*.js'],
         dest: 'tmp/ignores.js',
@@ -134,7 +143,19 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
+  function getTestTargets() {
+    var targetKeys = Object.keys(grunt.config('browserify'));
+    var optionsWithoutBundle = grunt.util._.without(targetKeys, 'onTheFlyBundle');
+
+    return ['clean']
+           .concat(optionsWithoutBundle.map(function (target) {
+              return 'browserify:' + target;
+            }))
+           .concat('nodeunit');
+  }
+
   // Default task.
-  grunt.registerTask('test', ['clean', 'browserify', 'nodeunit']);
+  grunt.registerTask('test', getTestTargets());
   grunt.registerTask('default', ['jshint', 'test']);
+
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-contrib-jshint": "0.1.x",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "jsdom": "~0.6.0"
+    "jsdom": "~0.6.0",
+    "hyperquest": "~0.1.7"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
I've added an option to serve the browserify bundle from an http server so there's no need for a watcher. This will re-bundle on the fly on every request. 

I still haven't added updates to the documentation, but I will if you think this feature is merge-able. Let me know your thoughts. 
