### PR TITLE
External files that are files should be files

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -62,7 +62,7 @@ module.exports = function (grunt) {
           aliases = aliases.split(',');
         }
 
-        aliases = grunt.util._.flatten(aliases)
+        aliases = grunt.util._.flatten(aliases);
 
         aliases.forEach(function (alias) {
           alias = alias.split(':');
@@ -122,7 +122,7 @@ module.exports = function (grunt) {
             if (expandedExternals.length > 0) {
               expandedExternals.forEach(function (dest) {
                 var externalResolved = path.resolve(dest);
-                if (grunt.file.exists(externalResolved)) {
+                if (grunt.file.exists(externalResolved) && grunt.file.isFile(externalResolved)) {
                   externalFiles.push(externalResolved);
                 }
                 else {


### PR DESCRIPTION
We were checking to see if the path existed, but not if it was a file.
This could cause edge-case errors if the path actually did exist, and 
an alias was created to point to the path.
