### PR TITLE
Reset `opts` var in `forEachSeries` loop

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,21 @@ module.exports = function (grunt) {
         }
       },
 
+      shimMulti: {
+        files: {
+          'tmp/shim-a.js': ['test/fixtures/shim/a.js', 'test/fixtures/shim/shim.js'],
+          'tmp/shim-b.js': ['test/fixtures/shim/a.js', 'test/fixtures/shim/shim.js']
+        },
+        options: {
+          shim: {
+            shimmedJQ: {
+              path: 'test/fixtures/shim/jquery.js',
+              exports: '$'
+            }
+          }
+        }
+      },
+
       sourceMaps: {
         src: ['test/fixtures/basic/*.js'],
         dest: 'tmp/sourceMaps.js',

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -15,13 +15,15 @@ var shim = require('browserify-shim');
 
 module.exports = function (grunt) {
   grunt.registerMultiTask('browserify', 'Grunt task for browserify.', function () {
-    var opts = this.options();
+    var task = this;
+    var opts;
     var ctorOpts = {};
     var shims;
 
 
     grunt.util.async.forEachSeries(this.files, function (file, next) {
       var aliases;
+      opts = task.options();
 
       ctorOpts.entries = grunt.file.expand({filter: 'isFile'}, file.src).map(function (f) {
         return path.resolve(f);
@@ -62,7 +64,7 @@ module.exports = function (grunt) {
           aliases = aliases.split(',');
         }
 
-        aliases = grunt.util._.flatten(aliases)
+        aliases = grunt.util._.flatten(aliases);
 
         aliases.forEach(function (alias) {
           alias = alias.split(':');

--- a/test/browserify_test.js
+++ b/test/browserify_test.js
@@ -231,6 +231,21 @@ module.exports = {
     test.done();
   },
 
+  shimMulti: function (test) {
+    test.expect(4);
+
+    ['tmp/shim-a.js', 'tmp/shim-b.js'].forEach(function (file) {
+      var context = getIncludedModules(file, domWindow());
+
+      test.ok(moduleExported(context, './fixtures/shim/a.js'));
+
+      //jquery is defined on the window
+      test.ok(context.window.$);
+    });
+
+    test.done();
+  },
+
   sourceMaps: function (test) {
     test.expect(1);
 


### PR DESCRIPTION
- reset opts on loop start because browserify modifies it
- fix up lint error
- add simple test to make sure multiple-file build with shim works correctly

fixes #94
