### PR TITLE
Loosen browserify version, and make a peer dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "browserify": "~2.27.0",
     "browserify-shim": "~2.0.8"
   },
   "devDependencies": {
@@ -40,6 +39,7 @@
     "jsdom": "~0.6.0"
   },
   "peerDependencies": {
+    "browserify": ">=2.27.0 < 3.0",
     "grunt": "~0.4.0"
   },
   "keywords": [


### PR DESCRIPTION
Making it easier for the end user to choose a specific/specialized browserify version.
