### PR TITLE
Update to browserify@~2.35 for dedupe fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "through": "~2.3.4"
   },
   "devDependencies": {
-    "browserify": "~2.33",
+    "browserify": "~2.35",
     "grunt-contrib-jshint": "0.1.x",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
     "jsdom": "~0.6.0"
   },
   "peerDependencies": {
-    "browserify": ">=2.33 < 3.0.0",
+    "browserify": ">=2.35 < 3.0.0",
     "grunt": "~0.4.0"
   },
   "keywords": [


### PR DESCRIPTION
Update Browserify version to ~2.35 to take advantage of this fix that was merged in today:

https://github.com/substack/node-browserify/pull/512

This fixes a bug with sourcemaps + alias, where a race condition would cause sourcemaps to often be wrong when using the `alias` or `aliasMappings` options.
