### PR TITLE
Grunt@0.4.2 external libraries deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "browserify-shim": "~2.0.8",
     "through": "~2.3.4",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "async": "~0.2.9"
   },
   "devDependencies": {
     "browserify": "~2.35",

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var through = require('through');
 var _ = require('lodash');
+var async = require('async');
 
 /*
  * grunt-browserify
@@ -23,7 +24,7 @@ module.exports = function (grunt) {
     var shims;
 
 
-    grunt.util.async.forEachSeries(this.files, function (file, next) {
+    async.forEachSeries(this.files, function (file, next) {
       var aliases;
       opts = task.options();
 


### PR DESCRIPTION
Grunt@0.4.2 makes external libraries deprecated (see [blog post](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released)). The corresponding npm modules should be used instead.
