### PR TITLE
Add preBundleCb option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,6 +156,17 @@ module.exports = function (grunt) {
         }
       },
 
+      preBundleCb: {
+        src: ['test/fixtures/ignore/*.js'],
+        dest: 'tmp/ignores-pre.js',
+        options: {
+          preBundleCB: function (bundle) {
+            var file = require('path').resolve('test/fixtures/ignore/ignore.js');
+            bundle.ignore(file);
+          }
+        }
+      },
+
       postBundleCB: {
         src: ['test/fixtures/basic/*.js'],
         dest: 'tmp/post.js',

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ Provide a config object to be used with
 shimmed modules are essentially `alias`ed as well (with the alias being
 the Object key of the shim).
 
+#### preBundleCB
+Type: `Function (b)`
+
+An optional callback function, that will be called before bundle completion.
+`b` is the `browerify` instance that will output the bundle.
+
 #### postBundleCB
 Type: `Function (err, src, next)`
 

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -220,6 +220,10 @@ module.exports = function (grunt) {
         grunt.file.mkdir(destPath);
       }
 
+      if (opts.preBundleCB) {
+        opts.preBundleCB(b);
+      }
+
       var onBundleComplete = function (err, src) {
         if (err) {
           grunt.log.error(err);

--- a/test/browserify_test.js
+++ b/test/browserify_test.js
@@ -286,7 +286,16 @@ module.exports = {
     test.ok(actual === 'Hello World!');
 
     test.done();
-  }
+  },
 
+  preCallback: function (test) {
+    test.expect(1);
+
+    var context = getIncludedModules('tmp/ignores-pre.js');
+
+    test.ok(moduleNotExported(context, './fixtures/ignore/ignore.js'));
+
+    test.done();
+  }
 };
 


### PR DESCRIPTION
Type: `Function (b)`

An optional callback function, that will be called before bundle completion.
`b` is the `browerify` instance that will output the bundle.

Example:

``` js
options: {
  preBundleCB: function (b) {
    b.on('file', function(file) {
      grunt.log.ok(file);
    });
  }
}
```
