### PR TITLE
use aliasify for aliasMappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "browserify-shim": "~2.0.10",
     "through": "~2.3.4",
     "lodash": "~2.4.1",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "aliasify": "~1.2.0"
   },
   "devDependencies": {
     "browserify": "~3.0",

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -25,7 +25,8 @@ module.exports = function (grunt) {
 
 
     async.forEachSeries(this.files, function (file, next) {
-      var aliases;
+      var aliases,
+          expandedAliases = {};
       opts = task.options();
 
       ctorOpts.entries = grunt.file.expand({filter: 'isFile'}, file.src).map(function (f) {
@@ -108,7 +109,7 @@ module.exports = function (grunt) {
           grunt.file.expandMapping(alias.src, alias.dest, alias)
             .forEach(function (file) {
               var expose = file.dest.substr(0, file.dest.lastIndexOf('.'));
-              b.require(path.resolve(file.src[0]), {expose: expose});
+              expandedAliases[expose] = './' + file.src[0];
             });
         });
       }
@@ -215,6 +216,13 @@ module.exports = function (grunt) {
         opts.transform.forEach(function (transform) {
           b.transform(transform);
         });
+      }
+
+      if (!_.isEmpty(expandedAliases)) {
+        var aliasify = require('aliasify').configure({
+          aliases: expandedAliases
+        });
+        b.transform(aliasify);
       }
 
       var destPath = path.dirname(path.resolve(file.dest));


### PR DESCRIPTION
Files matched by aliasMappings might not be `require`d by the modules that browserify is building, so using browserify to `require` those matched files is slow and wasteful. This PR changes to behavior of aliasMappings to instead rewrite `require` statements that match the aliasMappings files to use the actual relative file paths.

Verified that unit-tests pass.

addresses #127
