### PR TITLE
support `paths` option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,14 @@ module.exports = function (grunt) {
         }
       },
 
+      paths: {
+        src: ['test/fixtures/paths/paths.js'],
+        dest: 'tmp/paths.js',
+        options: {
+          paths: ['test/fixtures', 'test/fixtures/basic']
+        }
+      },
+
       external: {
         src: ['test/fixtures/external/entry.js', 'text/fixtures/external/b.js'],
         dest: 'tmp/external.js',

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Like the `alias` option described above, but accepts mapping patterns as describ
 directories and sets of files. Note that the `expand` option is set to `true` for you,
 so you can omit that from your configuration.
 
+#### paths
+Type: `[String]`
+
+Specifies paths to look in for required files
+
 #### external
 Type: `[String]`
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watchify": "~0.5.0"
   },
   "devDependencies": {
-    "browserify": "~3.0",
+    "browserify": ">=3.21.1 <4.0.0",
     "grunt-contrib-jshint": "0.1.x",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -91,6 +91,11 @@ module.exports = function (grunt) {
       delete taskOpts.noParse;
     }
 
+    if (taskOpts.paths) {
+      browserifyConstructorOpts.paths = taskOpts.paths;
+      delete taskOpts.paths;
+    }
+
     return taskOpts;
   };
 

--- a/test/browserify_test.js
+++ b/test/browserify_test.js
@@ -111,6 +111,16 @@ module.exports = {
     test.done();
   },
 
+  paths: function (test) {
+    test.expect(2);
+    var context = getIncludedModules('tmp/paths.js');
+
+    test.ok(moduleExported(context, './fixtures/basic/a.js'));
+    test.ok(moduleExported(context, './fixtures/basic/b.js'));
+
+    test.done();
+  },
+
   external: function (test) {
     test.expect(5);
 
@@ -241,7 +251,7 @@ module.exports = {
     test.expect(1);
 
     var actual = readFile('tmp/sourceMaps.js');
-    test.ok(actual.match(/\/\/@ sourceMappingURL=/));
+    test.ok(actual.match(/\/\/# sourceMappingURL=/));
 
     test.done();
   },

--- a/test/fixtures/paths/paths.js
+++ b/test/fixtures/paths/paths.js
@@ -1,0 +1,4 @@
+required({
+  a: require('basic/a'),
+  b: require('b')
+});


### PR DESCRIPTION
Ports @trevordixon's paths option to v2Dev.

I updated the grunt-browserify's devDependency for browserify to `>=3.21.1 <4.0.0`, which matches the string for watchify's browserify dependency. This way, people who install grunt-browserify are likely to run the same version of browserify no matter whether `watch: true` or `watch: false`. We should probably try to keep our version string roughly in sync with watchify's.

(If there was a way to avoid specifying browserify as a devDependency, and instead use watchify's install of browserify, that'd be even better -- I'm an npm/node newb so I don't know if there's a way to do this)

Closes #144 
