### PR TITLE
Corrects "extension" option as "extensions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ do not need to be parsed. (The Browserify docs provide the example of jQuery, al
 think it would probably be more useful to shim such libraries than to compile
 them with noParse).
 
-#### extension
+#### extensions
 Type: `[String]`
 
 Array of file extensions to consider EXTENSION as modules. 
 
 ##### example
 ```
-extension: [ '.coffee', '.js' ]
+extensions: [ '.coffee', '.js' ]
 ```
 
 The `require` function will now look for any files with either of those 2 extensions and treat them as modules if found.


### PR DESCRIPTION
Seems like this option name is actually "extensions" in practice.
