### PR TITLE
Handle being able to take transform args as an array with opts.

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -219,7 +219,11 @@ module.exports = function (grunt) {
 
       if (opts.transform) {
         opts.transform.forEach(function (transform) {
-          b.transform(transform);
+          if (_.isArray(transform)) {
+            b.transform(transform[1], transform[0]);
+          } else {
+            b.transform(transform);
+          }
         });
       }
 


### PR DESCRIPTION
Transform arguments can be passed in as a string such as...
`transform: ['es6ify']`
or you can wrap it in an array and have the second item be an options hash...
`transform: ['reactify', ['es6ify, {"global": true}]]`
