### PR TITLE
Expand external file globs. 

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -27,18 +27,20 @@ Task.runTask = function (grunt, options, file, next) {
     return path.resolve(f);
   });
 
-  // Expand file globs (ex: src/**/*.js)
-  var external = [];
-  options.external.forEach(function(id) {
-    if (id.match(':')) {
-      external.push(id);
-    } else {
-      return grunt.file.expand({filter: 'isFile'}, id).forEach(function (f) {
-        external.push(path.resolve(f));
-      });
-    }
-  });
-  options.external = external;
+  if (options.external) {
+    // Expand file globs (ex: src/**/*.js)
+    var external = [];
+    options.external.forEach(function(id) {
+      if (id.match(':')) {
+        external.push(id);
+      } else {
+        return grunt.file.expand({filter: 'isFile'}, id).forEach(function (f) {
+          external.push(path.resolve(f));
+        });
+      }
+    });
+    options.external = external;
+  }
 
   runner.run(files, file.dest, options, next);
 };


### PR DESCRIPTION
Fixes amitayd/grunt-browserify-jasmine-node-example#2

It looks like this used to work before 2.0. I hope it's removal was unintentional and this can be merged.

I did look at your test file, but it's not clear to me how I would add this to the automated tests. The existing tests still pass and this worked in my own project.
