### PR TITLE
Actually keeping the process alive if an error occurs

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -9,6 +9,7 @@ function GruntBrowserifyRunner(options) {
   this.watchify = options.watchify || require('watchify');
   this.logger = options.logger;
   this.writer = options.writer;
+  this.firstBuild = true;
 }
 
 GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
@@ -124,10 +125,10 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     var destPath = this.createDestDir(destination);
     var keepAlive = this.keepAliveFn.bind(this, options);
     var done = options.keepAlive? keepAlive : next;
-    var bundleComplete = this.onBundleComplete(destination, done);
+    var bundleComplete = this.onBundleComplete(destination, options, done);
 
     if (options.watch) {
-      var bundleUpdate = this.onBundleComplete(destination, keepAlive);
+      var bundleUpdate = this.onBundleComplete(destination, options, keepAlive);
       b.on('update', function (ids) {
         ids.forEach(function (id) {
           self.logger.log.ok(id + ' changed, updating browserify bundle.');
@@ -151,15 +152,19 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     this.logger.log.ok('Watchifying...');
   },
 
-  onBundleComplete: function (destination, next) {
+  onBundleComplete: function (destination, options, next) {
     var self = this;
     return function (err, src) {
       if (err) {
         self.logger.log.error(err);
-        self.logger.fail.warn('Error running grunt-browserify.');
+        if(self.firstBuild || !options.keepAlive) {
+            self.logger.fail.warn('Error running grunt-browserify.');
+        }
+      } else {
+        self.writer.write(destination, src + ';');
       }
 
-      self.writer.write(destination, src + ';');
+      self.firstBuild = false;
       next();
     };
   }


### PR DESCRIPTION
If you have a syntax error in your code the grunt process will fallover which is pretty annoying and contrary to what keepAlive is supposed to do. This commit fixes this behaviour. The only issue is that watchify appears to need to have been built successfully otherwise it just hangs so I've had to add a check to see if it has already built successfully otherwise it will fail.
