### PR TITLE
added globbing support for 'require' config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Browserify can alias files or modules to a certain name. For example, `require(â
 Type: `[String]`
 
 Specifies files to be required in the browserify bundle. String filenames are parsed into their full paths with `path.resolve`.
+Globbing patterns are supported.
 
 #### ignore
 Type: `[String]`

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,7 +64,7 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
 
     if (options.require) {
       _.forEach(options.require, function (file) {
-        b.require(file);
+        runOptionForGlob(b, 'require', file);
       });
     }
 

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -89,9 +89,12 @@ describe('grunt-browserify-runner', function () {
     it('requires each item in the array', function (done) {
       var b = stubBrowserify('require');
       var requireList = ['./package.json'];
+      var files = _.map(requireList, function (file) {
+        return path.resolve(file);
+      });      
       var runner = createRunner(b);
       runner.run([], dest, {require: requireList}, function () {
-        assert.ok(b().require.calledWith(requireList[0]));
+        assert.ok(b().require.calledWith(files[0]));
         done();
       });
     });


### PR DESCRIPTION
Added support for globbing in `require` configuration setting, which I left out in #176 , so it wasn't handled in #180.

Was tested on https://github.com/amitayd/grunt-browserify-jasmine-node-example/ .
