### PR TITLE
Upgrade watchify

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "async": "~0.2.9",
-    "watchify": "~0.5.0",
+    "watchify": "~0.6.0",
     "resolve": "~0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bug in watchify  0.5.x that was causing file change events to be
triggered multiple times. Watchify 0.6.x fixes this.

Update to #178
