### PR TITLE
BundleOptions were not being passed to `onBundleComplete`, breaking source maps.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -135,10 +135,10 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     var destPath = this.createDestDir(destination);
     var keepAlive = this.keepAliveFn.bind(this, options);
     var done = options.keepAlive? keepAlive : next;
-    var bundleComplete = this.onBundleComplete(destination, done);
+    var bundleComplete = this.onBundleComplete(destination, done, options.bundleOptions);
 
     if (options.watch) {
-      var bundleUpdate = this.onBundleComplete(destination, keepAlive, {allowErrors: true});
+      var bundleUpdate = this.onBundleComplete(destination, keepAlive, _.extend({allowErrors: true}, options.bundleOptions));
       b.on('update', function (ids) {
         ids.forEach(function (id) {
           self.logger.log.ok(id + ' changed, updating browserify bundle.');


### PR DESCRIPTION
`2.1.1` added a check for `options.debug` before automatically adding a source map, but the `bundleOptions` were not being passed to that file, making it impossible for `options.debug` to be true.

This breaks source maps, especially if run with `exorcist`:
![srcmap](http://i.imgur.com/5NPCV59.png)

To be honest, I don't think grunt-browserify should be doing any automatic semicolon insertion (browserify decided a few versions ago to stay away from that). It should be up to your other build tools to concat with semicolons at file breaks.
