### PR TITLE
Fix ignore of modules, simplify exclude

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -70,12 +70,7 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
 
     if (options.exclude) {
       _.forEach(options.exclude, function (file) {
-        if (testForGlob(file)) {
-          runOptionForGlob(b, 'exclude', file);
-        }
-        else {
-          b.exclude(file);
-        }
+        runOptionForGlob(b, 'exclude', file);
       });
     }
 
@@ -208,10 +203,10 @@ function testForGlob(id) {
 function runOptionForGlob(browserifyInstance, method, pattern) {
   var files = glob.sync(pattern);
   if (!files || files.length < 1) {
-    //it's not a glob, it's a file path
+    //it's not a glob, it's a file / module path
     files = [pattern];
   }
   files.forEach(function (f) {
-    browserifyInstance[method].call(browserifyInstance, path.resolve(f));
+    browserifyInstance[method].call(browserifyInstance, f);
   });
 }

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -111,9 +111,7 @@ describe('grunt-browserify-runner', function () {
     it('excludes globbed file results', function (done) {
       var b = stubBrowserify('exclude');
       var excludeList = ['./*.json'];
-      var files = _.map(['./package.json'], function (file) {
-        return path.resolve(file);
-      });
+      var files = ['./package.json'];
       var runner = createRunner(b);
       runner.run([], dest, {exclude: excludeList}, function () {
         assert.ok(b().exclude.calledWith(files[0]));
@@ -125,22 +123,18 @@ describe('grunt-browserify-runner', function () {
   describe('when passing option of ignore', function () {
     it('ignores the resolved filename of each item in the array', function (done) {
       var b = stubBrowserify('ignore');
-      var ignoreList = ['./package.json'];
-      var files = _.map(ignoreList, function (file) {
-        return path.resolve(file);
-      });
+      var ignoreList = ['./package.json', 'os'];
       var runner = createRunner(b);
       runner.run([], dest, {ignore: ignoreList}, function () {
-        assert.ok(b().ignore.calledWith(files[0]));
+        assert.ok(b().ignore.calledWith(ignoreList[0]));
+        assert.ok(b().ignore.calledWith(ignoreList[1]));
         done();
       });
     });
     it('ignores globbed file results', function (done) {
       var b = stubBrowserify('ignore');
       var ignoreList = ['./*.json'];
-      var files = _.map(['./package.json'], function (file) {
-        return path.resolve(file);
-      });
+      var files = ['./package.json'];
       var runner = createRunner(b);
       runner.run([], dest, {ignore: ignoreList}, function () {
         assert.ok(b().ignore.calledWith(files[0]));
@@ -220,7 +214,7 @@ describe('grunt-browserify-runner', function () {
         var externalList = ['./*.json', 'foobar'];
         var runner = createRunner(b);
         runner.run([], dest, {external: externalList}, function () {
-          assert.ok(b().external.calledWith(path.resolve('./package.json')));
+          assert.ok(b().external.calledWith('./package.json'));
           assert.ok(b().external.calledWith(externalList[1]));
           done();
         });


### PR DESCRIPTION
Previously, passing e.g. `ignore: ['buffer']` to a browserify job would not work; it would instead resolve the filepath to the local project directory.

Added a test to confirm the fix.

Glob handling is all we need here: see https://github.com/substack/node-browserify/blob/master/bin/args.js#L93 for where the globs are handled from the command line. See also https://github.com/substack/node-browserify/blob/master/index.js#L255 where both the raw name (e.g. `./package.json`) and `path.resolve('./package.json')` are added to the ignore list.
