### PR TITLE
Added support for Browserify `entries` option.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -19,7 +19,7 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
 
     //set constructor options and instantiate
     var bOpts = options.browserifyOptions || {};
-    bOpts.entries = files;
+    bOpts.entries = options.browserifyOptions.entries || files;
 
     // Watchify requires specific arguments
     if(options.watch) {


### PR DESCRIPTION
Minor modification to add support for Browserify's `opts.entries` (see [Browserify Ready - methods - constructor](https://github.com/substack/node-browserify#var-b--browserifyfiles-or-opts)). I believe it is important to support this option since it can prevent the immediate evaluation of a modules code, if desired.
