### PR TITLE
merge options.alias with options.require

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -37,19 +37,18 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
       throw new Error('bundleOptions is no longer used. Move all option in browserifyOptions.');
     }
 
-    // merge options.alias with options.require to get only 1 array of required files
-    var requiredFiles = _.merge(options.require || [], options.alias || []);
-    if (requiredFiles) {
-      _.forEach(requiredFiles, function (file) {
-        if(file.match(':')) {
-          var filePair = file.split(':');
-          b.require(filePair[0], {expose: filePair[1]});
-        }
-        else {
-          b.require(file);
-        }
-      });
-    }
+    // concat both array of require and alias
+    var requiredFiles = (options.require || []).concat(options.alias || []);
+    _.forEach(requiredFiles, function (file) {
+      if(file.match(':')) {
+        var filePair = file.split(':');
+        console.log(filePair)
+        b.require(filePair[0], {expose: filePair[1]});
+      }
+      else {
+        b.require(file);
+      }
+    });
 
     if (options.exclude) {
       _.forEach(options.exclude, function (file) {


### PR DESCRIPTION
Following this issue #230, I thought it could be a good idea to merge `options.require` and `options.alias`. It seems unclear to have 2 different options to do the same thing in browserify.

In browserify cli, with or without an exposed name, the option is still `-r myModule` or `-r myModule:myCustomName` so having the same feature in grunt-browserify would be nice.

Also, I didn't change the documentation to reflect this change. I think we should drop the alias option in the doc and only mention remapify to do dynamic alias mapping. To me when I first use grunt-browserify, it was unclear if I could have an alias without the plugin.
