### PR TITLE
Update require to expose as per browserify

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -40,13 +40,8 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     // concat both array of require and alias
     var requiredFiles = (options.require || []).concat(options.alias || []);
     _.forEach(requiredFiles, function (file) {
-      if(file.match(':')) {
-        var filePair = file.split(':');
-        b.require(filePair[0], {expose: filePair[1]});
-      }
-      else {
-        b.require(file);
-      }
+      var filePair = file.split(':');
+      b.require(filePair[0], {expose: filePair.length === 1 ? filePair[0] : filePair[1]});
     });
 
     if (options.exclude) {


### PR DESCRIPTION
As with Browserify CLI, require with no expose given should default to exposing the file path itself.

See https://github.com/substack/node-browserify/blob/master/bin/args.js#L138