### PR TITLE
Added support for passing options to watchify (watchifyOptions).

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ If true, invoke [watchify](https://github.com/substack/watchify) instead of brow
 Type: Boolean
 If true and if `watch` above is true, keep the Grunt process alive (simulates grunt-watch functionality).
 
+#### watchifyOptions
+Type: Object
+A hash of options that are passed to watchify during instantiation.
+[Watchify Github README](https://github.com/substack/watchify#var-w--watchifyb-opts)
+
 #### preBundleCB
 Type: `Function (b)`
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -21,13 +21,16 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     var bOpts = _.cloneDeep(options.browserifyOptions) || {};
     bOpts.entries = bOpts.entries || files;
 
+    // watchify options
+    var wOpts = options.watchifyOptions || {};
+
     // Watchify requires specific arguments
     if(options.watch) {
       bOpts = _.extend({ cache: {}, packageCache: {}, fullPaths: true }, bOpts);
     }
 
     //determine watchify or browserify
-    var b = options.watch ? this.watchify(this.browserify(bOpts)) : this.browserify(bOpts);
+    var b = options.watch ? this.watchify(this.browserify(bOpts), wOpts) : this.browserify(bOpts);
 
     b.on('error', function (err) {
       self.logger.fail.warn(err);

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -60,6 +60,20 @@ describe('grunt-browserify-runner', function () {
     });
   });
 
+  context('when passing option of watch:true with hash of watchifyOptions', function () {
+    var browserify = spyBrowserify();
+    var watchifyOpts = {chokidar: {usePolling: true}};
+    var baseOpts = {watch:true, watchifyOptions: watchifyOpts};
+    it('invokes watchify instead of browserify', function (done) {
+      var watchify = spyWatchify();
+      var runner = createRunner(browserify, watchify);
+      runner.run([], dest, baseOpts, function () {
+        assert.equal(watchify.callCount, 1);
+        assert.ok(watchify.calledWithMatch(browserify, watchifyOpts));
+        done();
+      });
+    });
+  });
 
   describe('when passing hash of browserifyOptions', function () {
     it('instantiates browserify with those options', function (done) {


### PR DESCRIPTION
Similar to how browserifyOptions are passed to browserify, this PR allows options in watchifyOptions to be passed to watchify.

Very useful in Docker containers, so we can pass chokidar.usePolling=true to watchify: https://github.com/substack/watchify/pull/126.