### PR TITLE
Run JSHint in Travis and remove peerDependencies

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,9 @@
 {
   "curly": true,
   "eqeqeq": true,
-  "es5": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
   "node": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
     },
 
     jshint: {
-      all: ['Gruntfile.js', 'tasks/**/*.js', '<%= nodeunit.tests %>'],
+      all: ['Gruntfile.js', 'tasks/**/*.js', 'lib/**/*.js', 'test/*.js'],
       options: {
         jshintrc: ".jshintrc"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">= 0.8.x"
   },
   "scripts": {
-    "test": "mocha -R spec --timeout 5000"
+    "test": "grunt && mocha -R spec --timeout 5000"
   },
   "dependencies": {
     "async": "^0.9.0",
@@ -38,13 +38,11 @@
     "watchify": "^2.4.0"
   },
   "devDependencies": {
+    "grunt": "^0.4.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "^0.11.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2"
-  },
-  "peerDependencies": {
-    "grunt": "^0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Was about to make a PR for something else and noticed that running `grunt` resulted in this error:

```
Running "jshint:all" (jshint) task
Warning: An error occurred while processing a template (Cannot read property 'tests' of undefined). Use --force to continue.
TypeError: An error occurred while processing a template (Cannot read property 'tests' of undefined).
    at eval (/lodash/template/source[1]:6:23)
    at Function.template (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/node_modules/lodash/lodash.js:3879:14)
    at Object.template.process (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/lib/grunt/template.js:75:27)
    at /Users/jonbretman/git/grunt-browserify/node_modules/grunt/lib/grunt/config.js:75:27
    at recurse (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/node_modules/grunt-legacy-util/index.js:127:14)
    at /Users/jonbretman/git/grunt-browserify/node_modules/grunt/node_modules/grunt-legacy-util/index.js:110:16
    at Array.map (native)
    at recurse (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/node_modules/grunt-legacy-util/index.js:109:20)
    at Object.util.recurse (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/node_modules/grunt-legacy-util/index.js:130:10)
    at Function.config.process (/Users/jonbretman/git/grunt-browserify/node_modules/grunt/lib/grunt/config.js:61:21)
```

So thought I would start by fixing that and getting JSHint running in Travis.

Also removed grunt from `peerDependencies` to `devDependencies` as `npm install` suggests:
```
npm WARN deprecation peerDependencies will no longer be
npm WARN deprecation installed implicitly in the next major
npm WARN deprecation version of npm (npm@3). You will need to
npm WARN deprecation switch to depending on them explicitly.
```