### PR TITLE
Allow options hash to be provided with each require item

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ Default: empty string
 The string will be prepended to the output. Template strings (e.g. `<%= config.value %>` will be expanded automatically.
 
 #### require
-Type: `[String]`
+Type: `[String]` or `[String:String]` or `[[String, Object]]`
 
-Specifies files to be required in the browserify bundle. String filenames are parsed into their full paths with `path.resolve`.
+Specifies files to be required in the browserify bundle. String filenames are parsed into their full paths with `path.resolve`. Aliases can be provided by using the `filePathString:aliasName` format.
+
+Each require can also be provided with an options hash; in this case, the require should be specified as an array of `[filePathString, optionsHash]`.
 
 #### ignore
 Type: `[String]`

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -43,8 +43,18 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
     // concat both array of require and alias
     var requiredFiles = (options.require || []).concat(options.alias || []);
     _.forEach(requiredFiles, function (file) {
-      var filePair = file.split(':');
-      b.require(filePair[0], {expose: filePair.length === 1 ? filePair[0] : filePair[1]});
+      var filePath, opts;
+      if (Array.isArray(file)) {
+        filePath = file[0];
+        opts = file[1];
+      } else {
+        var filePair = file.split(':');
+        filePath = filePair[0];
+        opts = {
+          expose: filePair.length === 1 ? filePair[0] : filePair[1]
+        };
+      }
+      b.require(filePath, opts);
     });
 
     if (options.exclude) {

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -97,6 +97,20 @@ describe('grunt-browserify-runner', function () {
         done();
       });
     });
+
+    context('if an options hash is provided', function () {
+      it('passes the options directly to require()', function (done) {
+        var b = stubBrowserify('require');
+        var requireList = [['./package.json', {entry: true, expose: 'expose-name'}]];
+        var runner = createRunner(b);
+        runner.run([], dest, {require: requireList}, function () {
+          var args = b().require.getCall(0).args;
+          assert.deepEqual(args, requireList[0]);
+          done();
+        });
+      });
+    });
+
   });
 
   describe('when passing option of exclude', function () {


### PR DESCRIPTION
So this was the PR I wanted to make originally :)

This allows an options hash to be provided when specifying requires in the same way that options can be provided to transforms.

* Added a test for this functionality
* Updated the README to explain this functionality