### PR TITLE
Add configure option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,19 @@ Type: Object
 A hash of options that are passed to watchify during instantiation.
 [Watchify Github README](https://github.com/substack/watchify#var-w--watchifyb-opts)
 
+#### configure
+Type: `Function (b)`
+
+An optional callback function that is invoked once before the bundle runs. This can be used for programatically configuring browserify using it's API.
+`b` is the `browserify` instance for the bundle.
+
 #### preBundleCB
 Type: `Function (b)`
 
 An optional callback function, that will be called before bundle completion.
 `b` is the `browerify` instance that will output the bundle.
+
+__NB:__ This callback will be invoked every time the bundle is built so when used with the `watch` option set to true it will be called multiple times. Do not register transforms in this callback or they will end up being registered multiple times.
 
 #### postBundleCB
 Type: `Function (err, src, next)`
@@ -188,6 +196,8 @@ An optional callback function, which will be called after bundle completion and
 before writing of the bundle. The `err` and `src` arguments are provided
 directly from browserify. The `next` callback should be called with `(err,
 modifiedSrc)`; the `modifiedSrc` is what will be written to the output file.
+
+__NB:__ This callback will be invoked every time the bundle is built so when used with the `watch` option set to true it will be called multiple times.
 
 
 ## Contributing

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -123,6 +123,10 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
       });
     }
 
+    if (options.configure) {
+      options.configure(b);
+    }
+
     doBundle(b, options, bundleComplete);
   },
 

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -264,6 +264,19 @@ describe('grunt-browserify-runner', function () {
     });
   });
 
+  describe('when passing option of configure', function () {
+    it('calls the provided callback before bundling', function (done) {
+      var cb = Sinon.stub();
+      var b = stubBrowserify('bundle');
+      var runner = createRunner(b);
+      runner.run([], dest, {configure: cb}, function () {
+        assert.ok(cb.calledOnce);
+        assert.ok(cb.calledBefore(b().bundle));
+        done();
+      });
+    });
+  });
+
   describe('when passing option of preBundleCB', function () {
     it('calls the provided callback before bundling', function (done) {
       var cb = Sinon.stub();


### PR DESCRIPTION
Closes #298 

Adds support for an optional `configure` callback function that gets executed once before the bundle is executed. This allows you to programatically configure the bundle using the browserify API. It differs to preBundleCB because the latter gets executed every time the bundle is executed, which when combined with watchify means the callback is executed multiple times. `configure`, however, only ever gets executed once which allows you to register transforms and event listeners without them being registered multiple times.