### PR TITLE
Update watchify to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "glob": "^4.4.1",
     "lodash": "^3.3.1",
     "resolve": "^1.1.5",
-    "watchify": "^2.4.0"
+    "watchify": "^2.5.0"
   },
   "devDependencies": {
     "grunt": "^0.4.0",


### PR DESCRIPTION
This solves an upstream bug that was making it impossible to properly require JSON files, amongst other issues, caused by a watchify change from a while ago.