### PR TITLE
Upgrade watchify to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^4.5.3",
     "lodash": "^3.5.0",
     "resolve": "^1.1.6",
-    "watchify": "^2.5.0"
+    "watchify": "^3.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.0",


### PR DESCRIPTION
[watchify](https://github.com/substack/watchify) 3.0.0 has added support for polling which is needed when running inside virtual environments such as Docker.

This was the PR that added the support - https://github.com/substack/watchify/pull/170/files