### PR TITLE
Removes array test for transform and plugin

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -87,23 +87,13 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
 
     if (options.transform) {
       _.forEach(options.transform, function (transformer) {
-        if (typeof transformer !== 'object') {
-          b.transform(transformer);
-        }
-        else {
-          b.transform(transformer[1], transformer[0]);
-        }
+        b.transform(transformer);
       });
     }
 
     if (options.plugin) {
       _.forEach(options.plugin, function (plugin) {
-        if (typeof plugin !== 'object') {
-          b.plugin(plugin);
-        }
-        else {
-          b.plugin(plugin[0], plugin[1]);
-        }
+        b.plugin(plugin);
       });
     }
 

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -257,7 +257,7 @@ describe('grunt-browserify-runner', function () {
       it('passes the options hash along with the transform fn', function (done) {
         var transforms = [[function () {}, {}]];
         runner.run([], dest, {transform: transforms}, function () {
-          assert.ok(b().transform.calledWith(transforms[0][1], transforms[0][0]));
+          assert.ok(b().transform.calledWith(transforms[0]));
           done();
         });
       });
@@ -307,9 +307,9 @@ describe('grunt-browserify-runner', function () {
     it('registers the plugin', function (done) {
       var b = stubBrowserify('plugin');
       var runner = createRunner(b);
-      var plugin = function () {};
-      runner.run([], dest, {plugin: [plugin]}, function () {
-        assert.ok(b().plugin.calledWith(plugin));
+      var plugin = [function () {}];
+      runner.run([], dest, {plugin: plugin}, function () {
+        assert.ok(b().plugin.calledWith(plugin[0]));
         done();
       });
     });
@@ -317,10 +317,9 @@ describe('grunt-browserify-runner', function () {
       it('registers the plugin options', function (done) {
         var b = stubBrowserify('plugin');
         var runner = createRunner(b);
-        var plugin = function () {};
-        var opts = {};
-        runner.run([], dest, {plugin: [[plugin, opts]]}, function () {
-          assert.ok(b().plugin.calledWith(plugin, opts));
+        var plugin = [[function () {}, {}]];
+        runner.run([], dest, {plugin: plugin}, function () {
+          assert.ok(b().plugin.calledWith(plugin[0]));
           done();
         });
       });


### PR DESCRIPTION
`browserify` supports to receive an array for these 2 API's (https://github.com/substack/node-browserify/blob/master/index.js#L271) so we can remove the array test we do.