### PR TITLE
Allow specifying run order for plugins/transforms.

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -85,24 +85,39 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
       });
     }
 
+    var steps = [];
+
     if (options.transform) {
       _.forEach(options.transform, function (transformer) {
-        if (typeof transformer !== 'object') {
-          b.transform(transformer);
-        }
-        else {
-          b.transform(transformer[1], transformer[0]);
-        }
+        steps.push({type: 'transform', step: transformer});
       });
     }
 
     if (options.plugin) {
       _.forEach(options.plugin, function (plugin) {
-        if (typeof plugin !== 'object') {
-          b.plugin(plugin);
+        steps.push({type: 'plugin', step: plugin});
+      });
+    }
+
+    if (options.pipeline) {
+      _.forEach(options.pipeline, function (stepname) {
+        _.forEach(steps, function(step) {
+          if (typeof step.step !== 'object' && step.step.name === stepname) {
+            b[step.type](step.step);
+          }
+          else if (step.step[0] === stepname) {
+            b[step.type](step.step[0], step.step[1]);
+          }
+        });
+      });
+    }
+    else {
+      _.forEach(steps, function (step) {
+        if (typeof step.step !== 'object') {
+          b[step.type](step.step);
         }
         else {
-          b.plugin(plugin[0], plugin[1]);
+          b[step.type](step.step[0], step.step[1]);
         }
       });
     }

--- a/test/browserify.test.js
+++ b/test/browserify.test.js
@@ -257,7 +257,7 @@ describe('grunt-browserify-runner', function () {
       it('passes the options hash along with the transform fn', function (done) {
         var transforms = [[function () {}, {}]];
         runner.run([], dest, {transform: transforms}, function () {
-          assert.ok(b().transform.calledWith(transforms[0][1], transforms[0][0]));
+          assert.ok(b().transform.calledWith(transforms[0][0], transforms[0][1]));
           done();
         });
       });


### PR DESCRIPTION
By default it maintains the previous behaviour of running all transforms in the order they are declared, followed by all plugins in the order they are declared.

This adds a new `pipeline` option, which is an array of plugin/transform names. The plugins/transforms will be run according to the order specified in the pipeline option. If a step is not specified, it will not be run.

Example:

```javascript
browserify: {
  options: {
    plugin: [['tsify', {target: 'ES5', removeComments: true}]],
    transform: [['browserify-ngannotate', {ext: '.ts'}]],
    pipeline: ['tsify', 'browserify-ngannotate']
  },
  build: {
    'output.js': ['main.ts', 'module.ts']
  }
}
```