### PR TITLE
Makes browserify-shim example functional

### DIFF
--- a/examples/browserify-shim/Gruntfile.js
+++ b/examples/browserify-shim/Gruntfile.js
@@ -9,5 +9,5 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.loadTasks('../../tasks');
+  grunt.loadNpmTasks('grunt-browserify');
 };

--- a/examples/browserify-shim/package.json
+++ b/examples/browserify-shim/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "~0.4.5",
+    "grunt-browserify": "^3.7.0"
   },
   "dependencies": {
     "browserify": "^9.0.3",


### PR DESCRIPTION
Example `browserify-shim` project doesn’t work out of the box. This
makes it so it does.