### PR TITLE
Additional add call added for require of external dependencies

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -54,6 +54,7 @@ GruntBrowserifyRunner.prototype = _.create(GruntBrowserifyRunner.prototype, {
           expose: filePair.length === 1 ? filePair[0] : filePair[1]
         };
       }
+      b.add(filePath);
       b.require(filePath, opts);
     });
 


### PR DESCRIPTION
In order to handle transforms right in the latest browserify version it is needed to call `b.add` before `b.require` is called.