### PR TITLE
updated watchify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "glob": "^5.0.5",
     "lodash": "^3.8.0",
     "resolve": "^1.1.6",
-    "watchify": "^3.2.1"
+    "watchify": "^3.2.2"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
When a module is exposed with:

```
browserify: {
  main: {
    src: 'app/app.js',
    dest: 'dist/registration.js'
  },
  options: {
    watchifyOptions: {
      debug: true
    },
    require: [
      ['./app/app.js', {expose: 'appName'}]
    ],
    watch: true
  },
}
```

and used like this:

```
<script>require('appName')({init: true})</script>
```

It works only once - when the bundle is created.
When the bundle is repackaged on watch the reference to the `expose` is lost. The `require` method throws an error.

The bug is upstream. Upgrading watchify solves the issue.