### PR TITLE
Added missing closing brackets for 'remapify' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ If you need alias mappings, you can use @joeybaker's [remapify plugin](https://g
 ```js
 options: {
   plugin: [
-  ['remapify', [
-    {
-      src: './client/views/**/*.js',  // glob for the files to remap
-      expose: 'views', // this will expose `__dirname + /client/views/home.js` as `views/home.js`
-      cwd: __dirname  // defaults to process.cwd()
-    }
+    [
+      'remapify', [{
+          src: './client/views/**/*.js',  // glob for the files to remap
+          expose: 'views', // this will expose `__dirname + /client/views/home.js` as `views/home.js`
+          cwd: __dirname  // defaults to process.cwd()
+        }
+      ]
+    ]
   ]
 }
 ```


### PR DESCRIPTION
Following the conversation on jmreidy/grunt-browserify#190 and reading the **README** file I found an error in the given example for the `'remapify'` plugin. It was missing some closing brackets which I have added now. :smiley: 