### PR TITLE
Use browserify@^11.0.1 and watchify@^3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "browserify": "^10.0.0",
+    "browserify": "^11.0.1",
     "glob": "^5.0.5",
     "lodash": "^3.8.0",
     "resolve": "^1.1.6",
-    "watchify": "^3.2.2"
+    "watchify": "^3.3.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Fixes https://github.com/substack/watchify/pull/250 by including this fix (https://github.com/substack/node-browserify/commit/90a429d6c22eefa61f73840ca212e7784666660a) for browserify.

cc: @tleunen  