### PR TITLE
Enable "update" event emitting for MacOS

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -190,7 +190,10 @@ function doBundle(browserifyInstance, opts, bundleComplete) {
     else {
       bundleComplete(err, buf);
     }
-  });
+  })
+  // Need this to ensure it works on MacOS
+  // See 'important' note here: https://github.com/substack/watchify#var-w--watchifyb-opts
+  .on('data', function() {});
 }
 
 function testForGlob(id) {


### PR DESCRIPTION
Fixed watchify mode for MacOS. 
Without this little patch rebuild is never started with `grutn-browserify` (while `watchify` itself from CLI works).
Based on [this comment](https://github.com/substack/watchify/issues/205#issuecomment-94064553) and  an `important` note from [here](https://github.com/substack/watchify#var-w--watchifyb-opts).