### PR TITLE
Update browserify to 14.1.0 to support async / await

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "browserify": "^13.0.0",
+    "browserify": "^14.1.0",
     "glob": "^6.0.3",
     "lodash": "^3.10.1",
     "resolve": "^1.1.6",


### PR DESCRIPTION
As per substack/node-browserify#1667 `acorn` is updated in the latest version of browserify so that `async/await` (now in Chrome AND node) is supported.