### PR TITLE
fix(deps): update browserify to version 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "^2.5.0",
-    "browserify": "^14.4.0",
+    "browserify": "^16.0.0",
     "browserify-incremental": "^3.1.1",
     "glob": "^7.1.2",
     "lodash": "^4.17.4",


### PR DESCRIPTION
`browserify@16` fixes an issue in its resolution algorithm which was causing trouble with [pnpm](https://github.com/pnpm/pnpm/)

fix https://github.com/pnpm/pnpm/issues/795