### PR TITLE
Upgrade watchify from 3.x to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "glob": "^7.1.2",
     "lodash": "^4.17.4",
     "resolve": "^1.1.6",
-    "watchify": "^3.6.1"
+    "watchify": "^4.0.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",


### PR DESCRIPTION
Version 3.x depends on `chokidar` 2.x that is incompatible with nodejs14. Upgrading `watchify` to 4.x so that the compatible (and smaller) `chokidar` is installed.